### PR TITLE
Remove NAT gateway

### DIFF
--- a/ecs/clusters/production/traccar/main.tf
+++ b/ecs/clusters/production/traccar/main.tf
@@ -40,6 +40,7 @@ module "alb" {
   
   app_port          = var.app_port
   health_check_path = var.health_check_path
+  allowed_cidr_blocks = var.allowed_ip_ranges
 }
 
 # ECS Task Definition for Traccar
@@ -74,12 +75,14 @@ module "ecs_service" {
   container_name      = module.ecs_task.container_name
   
   vpc_id             = data.terraform_remote_state.shared.outputs.vpc_id
-  subnets            = data.terraform_remote_state.shared.outputs.private_subnets
+  subnets            = data.terraform_remote_state.shared.outputs.public_subnets
   app_port           = var.app_port
   target_group_arn   = module.alb.target_group_arn
   desired_count      = var.desired_count
   min_capacity       = var.desired_count
   max_capacity       = var.max_capacity
+  alb_security_group_id = module.alb.security_group_id
+  assign_public_ip   = true
   
   create_security_group = true
 }

--- a/ecs/clusters/production/traccar/variables.tf
+++ b/ecs/clusters/production/traccar/variables.tf
@@ -51,3 +51,9 @@ variable "max_capacity" {
   type        = number
   default     = 1
 }
+
+variable "allowed_ip_ranges" {
+  description = "List of CIDR blocks allowed to access the ALB"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]  # Open to all by default, restrict in production
+}

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -8,14 +8,16 @@ resource "aws_security_group" "alb" {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.allowed_cidr_blocks
+    description = "Allow HTTP access from specified IP ranges"
   }
 
   ingress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.allowed_cidr_blocks
+    description = "Allow HTTPS access from specified IP ranges"
   }
 
   egress {

--- a/modules/alb/outputs.tf
+++ b/modules/alb/outputs.tf
@@ -7,3 +7,8 @@ output "target_group_arn" {
   description = "ARN of the target group"
   value       = aws_lb_target_group.app.arn
 }
+
+output "security_group_id" {
+  description = "ID of the ALB security group"
+  value       = aws_security_group.alb.id
+}

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -27,3 +27,9 @@ variable "project_name" {
   description = "Name of the project"
   type        = string
 }
+
+variable "allowed_cidr_blocks" {
+  description = "List of CIDR blocks allowed to access the ALB"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -11,11 +11,11 @@ resource "aws_security_group" "ecs_tasks" {
   vpc_id      = var.vpc_id
 
   ingress {
-    from_port   = var.app_port
-    to_port     = var.app_port
-    protocol    = "tcp"
-    description = "Allow inbound traffic to application port"
-    cidr_blocks = var.security_group_ingress_cidr
+    from_port       = var.app_port
+    to_port         = var.app_port
+    protocol        = "tcp"
+    description     = "Allow inbound traffic from ALB only"
+    security_groups = var.alb_security_group_id != "" ? [var.alb_security_group_id] : null
   }
 
   egress {

--- a/modules/ecs-service/variables.tf
+++ b/modules/ecs-service/variables.tf
@@ -97,3 +97,9 @@ variable "security_group_ingress_cidr" {
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }
+
+variable "alb_security_group_id" {
+  description = "Security group ID of the ALB to restrict inbound traffic"
+  type        = string
+  default     = ""
+}

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -24,10 +24,11 @@ resource "aws_subnet" "public" {
 
 # Private Subnets
 resource "aws_subnet" "private" {
-  count             = length(var.availability_zones)
-  vpc_id            = aws_vpc.main.id
-  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + length(var.availability_zones))
-  availability_zone = var.availability_zones[count.index]
+  count                   = length(var.availability_zones)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index + length(var.availability_zones))
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true  # Enable public IPs
 
   tags = {
     Name = "${var.project_name}-${var.environment}-private-subnet-${count.index + 1}"
@@ -41,29 +42,6 @@ resource "aws_internet_gateway" "main" {
   tags = {
     Name = "${var.project_name}-${var.environment}-igw"
   }
-}
-
-# Elastic IP for NAT Gateway
-resource "aws_eip" "nat" {
-  domain = "vpc"
-
-  tags = {
-    Name = "${var.project_name}-${var.environment}-nat-eip"
-  }
-
-  depends_on = [aws_internet_gateway.main]
-}
-
-# NAT Gateway
-resource "aws_nat_gateway" "main" {
-  allocation_id = aws_eip.nat.id
-  subnet_id     = aws_subnet.public[0].id
-
-  tags = {
-    Name = "${var.project_name}-${var.environment}-nat-gw"
-  }
-
-  depends_on = [aws_internet_gateway.main]
 }
 
 # Route table for public subnets
@@ -85,8 +63,8 @@ resource "aws_route_table" "private" {
   vpc_id = aws_vpc.main.id
 
   route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.main.id
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id  # Use Internet Gateway instead of NAT
   }
 
   tags = {


### PR DESCRIPTION
This pull request introduces changes to the infrastructure configuration for the `traccar` ECS cluster, focusing on improving security and simplifying networking by transitioning to public subnets and removing the NAT gateway. The changes include updates to security group rules, subnet configurations, and module variables to enhance flexibility and restrict access appropriately.

### Security and Access Control Improvements:
* Updated the ALB security group to use the `allowed_cidr_blocks` variable for ingress rules, allowing configurable IP ranges for HTTP and HTTPS access (`modules/alb/main.tf`).
* Added a new variable `allowed_cidr_blocks` to specify allowed CIDR blocks for ALB access, with a default value of `["0.0.0.0/0"]` (`modules/alb/variables.tf`, `ecs/clusters/production/traccar/variables.tf`). [[1]](diffhunk://#diff-40e1a2c71078a44d8469dbd7f69d9565b9809db0b66ba51adfb91e61c94da779R30-R35) [[2]](diffhunk://#diff-9620b8f488219b1447d33ca532d7843ec408f338ca098bca07eb80ce008aa1bdR54-R59)
* Restricted ECS tasks' security group ingress to traffic from the ALB only, using the `alb_security_group_id` variable (`modules/ecs-service/main.tf`).
* Introduced the `alb_security_group_id` variable to the ECS service module to support the above restriction (`modules/ecs-service/variables.tf`).

### Networking Simplification:
* Switched ECS services from private to public subnets and enabled public IP assignment for ECS tasks (`ecs/clusters/production/traccar/main.tf`).
* Removed the NAT gateway and associated Elastic IP configuration, replacing it with direct Internet Gateway routing for private subnets (`modules/networking/main.tf`). [[1]](diffhunk://#diff-c95f032328725cade38b1713aca82e0612f81cb0b090236c60613216b59e39baL46-L68) [[2]](diffhunk://#diff-c95f032328725cade38b1713aca82e0612f81cb0b090236c60613216b59e39baL89-R67)

### Additional Enhancements:
* Added an output for the ALB security group ID to the ALB module (`modules/alb/outputs.tf`).
* Enabled public IP assignment for private subnets in the networking module to support the updated ECS configuration (`modules/networking/main.tf`).